### PR TITLE
✨ Add chat history feature

### DIFF
--- a/src/main/store/chatSession.ts
+++ b/src/main/store/chatSession.ts
@@ -96,12 +96,20 @@ export class ChatSessionManager {
     const sessions = this.store.get('sessions')
     return recentIds
       .map((id) => sessions[id])
-      .filter((id) => id.messages.length > 0) // TODO: そもそも Session を作成するタイミングを調整することで length === 0 の Session が含まれないようにする
+      .filter((id) => id.messages.length > 0)
       .filter(Boolean)
   }
 
   getAllSessions(): ChatSession[] {
     const sessions = this.store.get('sessions')
     return Object.values(sessions).filter((i) => i.messages.length > 0)
+  }
+
+  setActiveSession(sessionId: string | undefined): void {
+    this.store.set('activeSessionId', sessionId)
+  }
+
+  getActiveSessionId(): string | undefined {
+    return this.store.get('activeSessionId')
   }
 }

--- a/src/main/store/chatSession.ts
+++ b/src/main/store/chatSession.ts
@@ -1,0 +1,107 @@
+import Store from 'electron-store'
+import { ChatHistoryStore, ChatSession, ChatMessage } from '../../types/chat/history'
+
+export class ChatSessionManager {
+  private store: Store<ChatHistoryStore>
+
+  constructor() {
+    this.store = new Store<ChatHistoryStore>({
+      name: 'chat-sessions',
+      defaults: {
+        sessions: {},
+        recentSessions: []
+      }
+    })
+  }
+
+  createSession(agentId: string, modelId: string, systemPrompt?: string): string {
+    const id = `session_${Date.now()}`
+    const session: ChatSession = {
+      id,
+      title: `Chat ${new Date().toLocaleString()}`,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+      messages: [],
+      agentId,
+      modelId,
+      systemPrompt
+    }
+
+    const sessions = this.store.get('sessions')
+    this.store.set('sessions', {
+      ...sessions,
+      [id]: session
+    })
+
+    this.updateRecentSessions(id)
+    return id
+  }
+
+  addMessage(sessionId: string, message: ChatMessage): void {
+    const sessions = this.store.get('sessions')
+    const session = sessions[sessionId]
+    if (!session) return
+
+    session.messages.push(message)
+    session.updatedAt = Date.now()
+
+    this.store.set('sessions', {
+      ...sessions,
+      [sessionId]: session
+    })
+
+    this.updateRecentSessions(sessionId)
+  }
+
+  getSession(sessionId: string): ChatSession | null {
+    const sessions = this.store.get('sessions')
+    return sessions[sessionId] || null
+  }
+
+  updateSessionTitle(sessionId: string, title: string): void {
+    const sessions = this.store.get('sessions')
+    const session = sessions[sessionId]
+    if (!session) return
+
+    session.title = title
+    session.updatedAt = Date.now()
+
+    this.store.set('sessions', {
+      ...sessions,
+      [sessionId]: session
+    })
+  }
+
+  deleteSession(sessionId: string): void {
+    const sessions = this.store.get('sessions')
+    const { [sessionId]: deletedSession, ...remainingSessions } = sessions
+    console.log({ deletedSession })
+    this.store.set('sessions', remainingSessions)
+
+    const recentSessions = this.store.get('recentSessions')
+    this.store.set(
+      'recentSessions',
+      recentSessions.filter((id) => id !== sessionId)
+    )
+  }
+
+  private updateRecentSessions(sessionId: string): void {
+    const recentSessions = this.store.get('recentSessions')
+    const updated = [sessionId, ...recentSessions.filter((id) => id !== sessionId)].slice(0, 10)
+    this.store.set('recentSessions', updated)
+  }
+
+  getRecentSessions(): ChatSession[] {
+    const recentIds = this.store.get('recentSessions')
+    const sessions = this.store.get('sessions')
+    return recentIds
+      .map((id) => sessions[id])
+      .filter((id) => id.messages.length > 0) // TODO: そもそも Session を作成するタイミングを調整することで length === 0 の Session が含まれないようにする
+      .filter(Boolean)
+  }
+
+  getAllSessions(): ChatSession[] {
+    const sessions = this.store.get('sessions')
+    return Object.values(sessions).filter((i) => i.messages.length > 0)
+  }
+}

--- a/src/preload/chat-history.ts
+++ b/src/preload/chat-history.ts
@@ -1,0 +1,34 @@
+import { ChatMessage } from '../types/chat/history'
+import { ChatSessionManager } from '../main/store/chatSession'
+
+const chatSessionManager = new ChatSessionManager()
+
+export const chatHistory = {
+  createSession(agentId: string, modelId: string, systemPrompt?: string) {
+    return chatSessionManager.createSession(agentId, modelId, systemPrompt)
+  },
+
+  addMessage(sessionId: string, message: ChatMessage) {
+    return chatSessionManager.addMessage(sessionId, message)
+  },
+
+  getSession(sessionId: string) {
+    return chatSessionManager.getSession(sessionId)
+  },
+
+  updateSessionTitle(sessionId: string, title: string) {
+    return chatSessionManager.updateSessionTitle(sessionId, title)
+  },
+
+  deleteSession(sessionId: string) {
+    return chatSessionManager.deleteSession(sessionId)
+  },
+
+  getRecentSessions() {
+    return chatSessionManager.getRecentSessions()
+  },
+
+  getAllSessions() {
+    return chatSessionManager.getAllSessions()
+  }
+}

--- a/src/preload/chat-history.ts
+++ b/src/preload/chat-history.ts
@@ -30,5 +30,13 @@ export const chatHistory = {
 
   getAllSessions() {
     return chatSessionManager.getAllSessions()
+  },
+
+  setActiveSession(sessionId: string | undefined) {
+    return chatSessionManager.setActiveSession(sessionId)
+  },
+
+  getActiveSessionId() {
+    return chatSessionManager.getActiveSessionId()
   }
 }

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -9,16 +9,14 @@ interface ChatHistoryAPI {
   deleteSession(sessionId: string): void
   getRecentSessions(): ChatSession[]
   getAllSessions(): ChatSession[]
+  setActiveSession(sessionId: string | undefined): void
+  getActiveSessionId(): string | undefined
 }
 
 declare global {
   interface Window {
     electron: ElectronAPI
-    api: {
-      bedrock: {
-        executeTool: (name: string, input: any) => Promise<string>
-      }
-    }
+    api: API
     store: any // 既存のstore型があればそれに合わせてください
     file: any // 既存のfile型があればそれに合わせてください
     tools: any // 既存のtools型があればそれに合わせてください

--- a/src/preload/index.d.ts
+++ b/src/preload/index.d.ts
@@ -1,15 +1,27 @@
 import { ElectronAPI } from '@electron-toolkit/preload'
-import { API } from './api'
-import { FileHandler } from './file'
-import { ConfigStore } from './store'
-import { Tool } from '@aws-sdk/client-bedrock-runtime'
+import { ChatMessage, ChatSession } from '../types/chat/history'
+
+interface ChatHistoryAPI {
+  createSession(agentId: string, modelId: string, systemPrompt?: string): string
+  addMessage(sessionId: string, message: ChatMessage): void
+  getSession(sessionId: string): ChatSession | null
+  updateSessionTitle(sessionId: string, title: string): void
+  deleteSession(sessionId: string): void
+  getRecentSessions(): ChatSession[]
+  getAllSessions(): ChatSession[]
+}
 
 declare global {
   interface Window {
     electron: ElectronAPI
-    api: API
-    store: ConfigStore
-    file: FileHandler
-    tools: Tool[]
+    api: {
+      bedrock: {
+        executeTool: (name: string, input: any) => Promise<string>
+      }
+    }
+    store: any // 既存のstore型があればそれに合わせてください
+    file: any // 既存のfile型があればそれに合わせてください
+    tools: any // 既存のtools型があればそれに合わせてください
+    chatHistory: ChatHistoryAPI
   }
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4,6 +4,7 @@ import { api } from './api'
 import { store } from './store'
 import { file } from './file'
 import { tools } from './tools/tools'
+import { chatHistory } from './chat-history'
 
 // Use `contextBridge` APIs to expose Electron APIs to
 // renderer only if context isolation is enabled, otherwise
@@ -15,6 +16,7 @@ if (process.contextIsolated) {
     contextBridge.exposeInMainWorld('store', store)
     contextBridge.exposeInMainWorld('file', file)
     contextBridge.exposeInMainWorld('tools', tools)
+    contextBridge.exposeInMainWorld('chatHistory', chatHistory)
   } catch (error) {
     console.error(error)
   }
@@ -29,4 +31,6 @@ if (process.contextIsolated) {
   window.file = file
   // @ts-ignore (define in dts)
   window.tools = tools
+  // @ts-ignore (define in dts)
+  window.chatHistory = chatHistory
 }

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -17,11 +17,7 @@ interface ChatHistoryAPI {
 declare global {
   interface Window {
     electron: ElectronAPI
-    api: {
-      bedrock: {
-        executeTool: (name: string, input: any) => Promise<string>
-      }
-    }
+    api: API
     store: any
     file: any
     tools: any

--- a/src/renderer/src/env.d.ts
+++ b/src/renderer/src/env.d.ts
@@ -1,24 +1,30 @@
 /// <reference types="vite/client" />
 
-interface ImportMetaEnv {
-  readonly PRELOAD_VITE_PEXELS_API_KEY: string
-  // more env variables...
+import { ElectronAPI } from '@electron-toolkit/preload'
+import { ChatMessage, ChatSession } from '../../types/chat/history'
+
+interface ChatHistoryAPI {
+  createSession(agentId: string, modelId: string, systemPrompt?: string): string
+  addMessage(sessionId: string, message: ChatMessage): void
+  getSession(sessionId: string): ChatSession | null
+  updateSessionTitle(sessionId: string, title: string): void
+  deleteSession(sessionId: string): void
+  getAllSessions(): ChatSession[]
+  setActiveSession(sessionId: string | undefined): void
+  getActiveSessionId(): string | undefined
 }
 
-interface ImportMeta {
-  readonly env: ImportMetaEnv
-}
-
-interface Window {
-  api: {
-    bedrock: {
-      executeTool: (toolName: string, toolInput: any) => Promise<any>
+declare global {
+  interface Window {
+    electron: ElectronAPI
+    api: {
+      bedrock: {
+        executeTool: (name: string, input: any) => Promise<string>
+      }
     }
-    contextMenu: {
-      onContextMenuCommand: (callback: (command: string) => void) => void
-    }
-    images: {
-      getLocalImage: (path: string) => Promise<string>
-    }
+    store: any
+    file: any
+    tools: any
+    chatHistory: ChatHistoryAPI
   }
 }

--- a/src/renderer/src/i18n/locales/chat/history.ts
+++ b/src/renderer/src/i18n/locales/chat/history.ts
@@ -1,0 +1,14 @@
+export const history = {
+  en: {
+    'Chat History': 'Chat History',
+    'Edit title': 'Edit title',
+    Delete: 'Delete',
+    'No chat history': 'No chat history'
+  },
+  ja: {
+    'Chat History': 'チャット履歴',
+    'Edit title': '名前を変更する',
+    Delete: '削除する',
+    'No chat history': 'チャット履歴はありません'
+  }
+}

--- a/src/renderer/src/i18n/locales/chat/history.ts
+++ b/src/renderer/src/i18n/locales/chat/history.ts
@@ -3,12 +3,14 @@ export const history = {
     'Chat History': 'Chat History',
     'Edit title': 'Edit title',
     Delete: 'Delete',
-    'No chat history': 'No chat history'
+    'No chat history': 'No chat history',
+    'Generate title': 'Geneate title'
   },
   ja: {
     'Chat History': 'チャット履歴',
     'Edit title': '名前を変更する',
     Delete: '削除する',
-    'No chat history': 'チャット履歴はありません'
+    'No chat history': 'チャット履歴はありません',
+    'Geneate title': '名前を生成する'
   }
 }

--- a/src/renderer/src/i18n/locales/chat/index.ts
+++ b/src/renderer/src/i18n/locales/chat/index.ts
@@ -23,7 +23,8 @@ export const chatPage = {
           sendMessage: 'Send message',
           sending: 'Sending...'
         }
-      }
+      },
+      confirmClearChat: 'Are you sure you want to clear the chat?'
     }
   },
   ja: {
@@ -45,7 +46,8 @@ export const chatPage = {
           sendMessage: 'メッセージを送信',
           sending: '送信中...'
         }
-      }
+      },
+      confirmClearChat: 'チャットをクリアしてもよろしいですか？'
     }
   }
 }

--- a/src/renderer/src/i18n/locales/chat/index.ts
+++ b/src/renderer/src/i18n/locales/chat/index.ts
@@ -1,12 +1,14 @@
 import { agent } from './agent'
 import { examples } from './examples'
 import { messages } from './messages'
+import { history } from './history'
 
 export const chatPage = {
   en: {
     ...agent.en,
     ...examples.en,
     ...messages.en,
+    ...history.en,
     ...{
       textarea: {
         placeholder: 'Type message or add images ({{modifier}}+V / drop)',
@@ -28,6 +30,7 @@ export const chatPage = {
     ...agent.ja,
     ...examples.ja,
     ...messages.ja,
+    ...history.ja,
     ...{
       textarea: {
         placeholder: 'メッセージを入力、または画像を追加 ({{modifier}}+V / ドロップ)',

--- a/src/renderer/src/lib/api.ts
+++ b/src/renderer/src/lib/api.ts
@@ -12,14 +12,16 @@ export type StreamChatCompletionProps = {
 const API_ENDPOINT = window.store.get('apiEndpoint')
 
 export async function* streamChatCompletion(
-  props: StreamChatCompletionProps
+  props: StreamChatCompletionProps,
+  abortSignal?: AbortSignal
 ): AsyncGenerator<ConverseStreamOutput, void, unknown> {
   const res = await fetch(`${API_ENDPOINT}/converse/stream`, {
     method: 'POST',
     body: JSON.stringify(props),
     headers: {
       'Content-Type': 'application/json'
-    }
+    },
+    signal: abortSignal
   })
   const reader = res.body?.getReader()
 
@@ -35,34 +37,39 @@ export async function* streamChatCompletion(
     throw new Error(msg)
   }
 
-  let done = false
-  while (!done) {
-    const { done: readDone, value } = await reader.read()
-    if (readDone) {
-      done = readDone
-      reader.releaseLock()
-    } else {
-      let token = decoder.decode(value, { stream: true })
+  try {
+    let done = false
+    while (!done) {
+      const { done: readDone, value } = await reader.read()
+      if (readDone) {
+        done = readDone
+        reader.releaseLock()
+      } else {
+        let token = decoder.decode(value, { stream: true })
 
-      const boundary = token.lastIndexOf(`\n`)
-      // 2つ以上の JSON オブジェクトが連なっている場合
-      if (boundary !== -1) {
-        const completeData = token.substring(0, boundary)
-        token = token.substring(boundary + 1)
+        const boundary = token.lastIndexOf(`\n`)
+        // 2つ以上の JSON オブジェクトが連なっている場合
+        if (boundary !== -1) {
+          const completeData = token.substring(0, boundary)
+          token = token.substring(boundary + 1)
 
-        for (const chunk of completeData.split('\n')) {
-          if (chunk) {
-            try {
-              yield JSON.parse(chunk)
-            } catch (e) {
-              console.error(`Error parsing JSON:`, e)
+          for (const chunk of completeData.split('\n')) {
+            if (chunk) {
+              try {
+                yield JSON.parse(chunk)
+              } catch (e) {
+                console.error(`Error parsing JSON:`, e)
+              }
             }
           }
+        } else {
+          yield JSON.parse(token)
         }
-      } else {
-        yield JSON.parse(token)
       }
     }
+  } catch (error) {
+    reader.releaseLock()
+    throw error
   }
 }
 
@@ -73,24 +80,29 @@ type ConverseProps = {
   toolConfig?: ToolConfiguration
 }
 
-export async function converse(props: ConverseProps) {
+export async function converse(props: ConverseProps, abortSignal?: AbortSignal) {
   const res = await fetch(`${API_ENDPOINT}/converse`, {
     method: 'POST',
     body: JSON.stringify(props),
     headers: {
       'Content-Type': 'application/json'
-    }
+    },
+    signal: abortSignal
   })
   return res.json()
 }
 
-export async function retrieveAndGenerate(props: RetrieveAndGenerateCommandInput) {
+export async function retrieveAndGenerate(
+  props: RetrieveAndGenerateCommandInput,
+  abortSignal?: AbortSignal
+) {
   const res = await fetch(`${API_ENDPOINT}/retrieveAndGenerate`, {
     method: 'POST',
     body: JSON.stringify(props),
     headers: {
       'Content-Type': 'application/json'
-    }
+    },
+    signal: abortSignal
   })
   return res
 }

--- a/src/renderer/src/pages/ChatPage/ChatPage.tsx
+++ b/src/renderer/src/pages/ChatPage/ChatPage.tsx
@@ -123,7 +123,7 @@ export default function ChatPage() {
           <div className="flex flex-row h-full">
             {/* チャット履歴サイドパネル */}
             <div
-              className={`dark:bg-gray-800 transition-all duration-300 ${
+              className={`dark:bg-gray-900 transition-all duration-300 ${
                 isHistoryOpen ? 'w-96' : 'w-0'
               } overflow-y-scroll`}
             >
@@ -137,7 +137,7 @@ export default function ChatPage() {
             <div className="flex items-center">
               <div
                 onClick={() => setIsHistoryOpen(!isHistoryOpen)}
-                className="w-4 h-16 bg-gray-100 hover:bg-gray-200 cursor-pointer flex items-center justify-center transition-colors duration-200 rounded-lg"
+                className="w-4 h-16 dark:bg-gray-800 hover:dark:bg-gray-700 bg-gray-100 hover:bg-gray-200 cursor-pointer flex items-center justify-center transition-colors duration-200 rounded-lg"
                 title={t('Toggle chat history')}
               >
                 <FiChevronRight

--- a/src/renderer/src/pages/ChatPage/ChatPage.tsx
+++ b/src/renderer/src/pages/ChatPage/ChatPage.tsx
@@ -49,11 +49,12 @@ export default function ChatPage() {
   const currentScenarios = currentAgent?.scenarios || []
 
   const { enabledTools, ToolSettingModal, openModal: openToolSettingModal } = useToolSettingModal()
-  const { messages, loading, handleSubmit, currentSessionId, setCurrentSessionId } = useAgentChat(
-    llm?.modelId,
-    systemPrompt,
-    enabledTools?.filter((tool) => tool.enabled)
-  )
+  const { messages, loading, handleSubmit, currentSessionId, setCurrentSessionId, clearChat } =
+    useAgentChat(
+      llm?.modelId,
+      systemPrompt,
+      enabledTools?.filter((tool) => tool.enabled)
+    )
 
   const onSubmit = (input: string, images: AttachedImage[]) => {
     handleSubmit(input, images)
@@ -69,6 +70,13 @@ export default function ChatPage() {
   }
   const handleCloseSystemPrompt = () => {
     setShowSystemPrompt(false)
+  }
+
+  const handleClearChat = () => {
+    if (window.confirm(t('confirmClearChat'))) {
+      clearChat()
+      setUserInput('')
+    }
   }
 
   useEffect(() => {
@@ -180,6 +188,8 @@ export default function ChatPage() {
             onOpenToolSettings={openToolSettingModal}
             onSelectDirectory={selectDirectory}
             onOpenIgnoreModal={openIgnoreModal}
+            onClearChat={handleClearChat}
+            hasMessages={messages.length > 0}
           />
         </div>
       </div>

--- a/src/renderer/src/pages/ChatPage/ChatPage.tsx
+++ b/src/renderer/src/pages/ChatPage/ChatPage.tsx
@@ -10,11 +10,12 @@ import useScroll from '@renderer/hooks/useScroll'
 import useIgnoreFileModal from './modals/useIgnoreFileModal'
 import useToolSettingModal from './modals/useToolSettingModal'
 import useAgentSettingsModal from './modals/useAgentSettingsModal'
-import { FiSettings } from 'react-icons/fi'
+import { FiSettings, FiChevronRight } from 'react-icons/fi'
 import { useTranslation } from 'react-i18next'
 import SystemPromptModal from './components/SystemPromptModal'
 import { AttachedImage } from './components/InputForm/TextArea'
 import { useDefaultAgents } from './hooks/useDefaultAgents'
+import { ChatHistory } from './components/ChatHistory'
 
 export default function ChatPage() {
   const [userInput, setUserInput] = useState('')
@@ -36,7 +37,6 @@ export default function ChatPage() {
 
   const baseAgents = useDefaultAgents()
 
-  // カスタムエージェントと基本エージェントを結合
   const allAgents = useMemo(() => {
     return [...baseAgents, ...customAgents]
   }, [baseAgents, customAgents])
@@ -49,7 +49,7 @@ export default function ChatPage() {
   const currentScenarios = currentAgent?.scenarios || []
 
   const { enabledTools, ToolSettingModal, openModal: openToolSettingModal } = useToolSettingModal()
-  const { messages, loading, handleSubmit } = useAgentChat(
+  const { messages, loading, handleSubmit, currentSessionId, setCurrentSessionId } = useAgentChat(
     llm?.modelId,
     systemPrompt,
     enabledTools?.filter((tool) => tool.enabled)
@@ -75,11 +75,18 @@ export default function ChatPage() {
     scrollToBottom()
   }, [loading, messages.length])
 
+  const [isHistoryOpen, setIsHistoryOpen] = useState(false)
+
+  const handleSessionSelect = (sessionId: string) => {
+    setCurrentSessionId(sessionId)
+  }
+
   return (
     <React.Fragment>
-      <div className={`flex flex-col h-[calc(100vh-11rem)] overflow-y-auto`} id="main">
-        <div className="flex justify-between items-center mb-4">
-          <div>
+      <div className="flex h-[calc(100vh-11rem)]">
+        <div className="flex-1 flex flex-col overflow-y-auto">
+          {/* ヘッダー */}
+          <div className="flex justify-between items-center mb-4">
             {allAgents.length > 1 ? (
               <AgentSelector
                 agents={allAgents}
@@ -88,63 +95,93 @@ export default function ChatPage() {
                 openable={messages.length === 0}
               />
             ) : null}
-          </div>
-          <div className="flex items-center gap-2">
-            <button
-              onClick={openAgentSettingsModal}
-              className="p-2 text-gray-500 hover:text-gray-700 rounded-full hover:bg-gray-100"
-              title={t('agent settings')}
-            >
-              <FiSettings className="w-5 h-5" />
-            </button>
-            <span
-              className="text-xs text-gray-400 font-thin cursor-pointer hover:text-gray-700"
-              onClick={handleOpenSystemPrompt}
-            >
-              SYSTEM_PROMPT
-            </span>
-          </div>
-        </div>
 
-        <SystemPromptModal
-          isOpen={showSystemPrompt}
-          onClose={handleCloseSystemPrompt}
-          systemPrompt={systemPrompt}
-        />
-        <AgentSettingsModal />
-        <ToolSettingModal />
-        <IgnoreFileModal />
-
-        <div className="flex flex-col gap-4 h-full">
-          {messages.length === 0 ? (
-            <div className="flex flex-col pt-12 h-full w-full justify-center items-center content-center align-center gap-1">
-              <div className="flex flex-row gap-3 items-center mb-2">
-                <div className="h-6 w-6">
-                  <AILogo />
-                </div>
-                <h1 className="text-lg font-bold dark:text-white">Agent Chat</h1>
-              </div>
-              <div className="text-gray-400">{currentAgent?.description}</div>
-              {currentAgent && (
-                <ExampleScenarios scenarios={currentScenarios} onSelectScenario={setUserInput} />
-              )}
+            <div className="flex items-center gap-2">
+              <button
+                onClick={openAgentSettingsModal}
+                className="p-2 text-gray-500 hover:text-gray-700 rounded-full hover:bg-gray-100"
+                title={t('agent settings')}
+              >
+                <FiSettings className="w-5 h-5" />
+              </button>
+              <span
+                className="text-xs text-gray-400 font-thin cursor-pointer hover:text-gray-700"
+                onClick={handleOpenSystemPrompt}
+              >
+                SYSTEM_PROMPT
+              </span>
             </div>
-          ) : null}
+          </div>
+          <SystemPromptModal
+            isOpen={showSystemPrompt}
+            onClose={handleCloseSystemPrompt}
+            systemPrompt={systemPrompt}
+          />
+          <AgentSettingsModal />
+          <ToolSettingModal />
+          <IgnoreFileModal />
+          <div className="flex flex-row h-full">
+            {/* チャット履歴サイドパネル */}
+            <div
+              className={`dark:bg-gray-800 transition-all duration-300 ${
+                isHistoryOpen ? 'w-96' : 'w-0'
+              } overflow-y-scroll`}
+            >
+              <ChatHistory
+                onSessionSelect={handleSessionSelect}
+                currentSessionId={currentSessionId}
+              />
+            </div>
 
-          <MessageList messages={messages} loading={loading} />
+            {/* 履歴トグルバー */}
+            <div className="flex items-center">
+              <div
+                onClick={() => setIsHistoryOpen(!isHistoryOpen)}
+                className="w-4 h-16 bg-gray-100 hover:bg-gray-200 cursor-pointer flex items-center justify-center transition-colors duration-200 rounded-lg"
+                title={t('Toggle chat history')}
+              >
+                <FiChevronRight
+                  className={`w-4 h-4 text-gray-500 transition-transform duration-200 ${
+                    isHistoryOpen ? 'rotate-180' : ''
+                  }`}
+                />
+              </div>
+            </div>
+
+            {/* メイン領域 */}
+            <div className="flex flex-col gap-4 w-full overflow-y-scroll">
+              {messages.length === 0 ? (
+                <div className="flex flex-col pt-12 h-full w-full justify-center items-center content-center align-center gap-1">
+                  <div className="flex flex-row gap-3 items-center mb-2">
+                    <div className="h-6 w-6">
+                      <AILogo />
+                    </div>
+                    <h1 className="text-lg font-bold dark:text-white">Agent Chat</h1>
+                  </div>
+                  <div className="text-gray-400">{currentAgent?.description}</div>
+                  {currentAgent && (
+                    <ExampleScenarios
+                      scenarios={currentScenarios}
+                      onSelectScenario={setUserInput}
+                    />
+                  )}
+                </div>
+              ) : null}
+              <MessageList messages={messages} loading={loading} />
+            </div>
+          </div>
+          <InputForm
+            userInput={userInput}
+            loading={loading}
+            projectPath={projectPath}
+            sendMsgKey={sendMsgKey}
+            onSubmit={(input, attachedImages) => onSubmit(input, attachedImages)}
+            onChange={setUserInput}
+            onOpenToolSettings={openToolSettingModal}
+            onSelectDirectory={selectDirectory}
+            onOpenIgnoreModal={openIgnoreModal}
+          />
         </div>
-
-        <InputForm
-          userInput={userInput}
-          loading={loading}
-          projectPath={projectPath}
-          sendMsgKey={sendMsgKey}
-          onSubmit={(input, attachedImages) => onSubmit(input, attachedImages)}
-          onChange={setUserInput}
-          onOpenToolSettings={openToolSettingModal}
-          onSelectDirectory={selectDirectory}
-          onOpenIgnoreModal={openIgnoreModal}
-        />
       </div>
     </React.Fragment>
   )

--- a/src/renderer/src/pages/ChatPage/components/ChatHistory/index.tsx
+++ b/src/renderer/src/pages/ChatPage/components/ChatHistory/index.tsx
@@ -1,0 +1,173 @@
+import React, { useEffect, useState } from 'react'
+import { ChatSession } from '@/types/chat/history'
+import { useTranslation } from 'react-i18next'
+import { FiMoreHorizontal, FiEdit2, FiTrash2 } from 'react-icons/fi'
+
+interface ChatHistoryProps {
+  onSessionSelect: (sessionId: string) => void
+  currentSessionId?: string
+}
+
+export const ChatHistory: React.FC<ChatHistoryProps> = ({ onSessionSelect, currentSessionId }) => {
+  const [recentSessions, setRecentSessions] = useState<ChatSession[]>([])
+  const [editingSessionId, setEditingSessionId] = useState<string>()
+  const [editTitle, setEditTitle] = useState('')
+  const [menuOpenSessionId, setMenuOpenSessionId] = useState<string>()
+  const [isComposing, setIsComposing] = useState(false)
+  const { t } = useTranslation()
+
+  useEffect(() => {
+    const sessions = window.chatHistory.getAllSessions()
+    setRecentSessions(sessions)
+  }, [])
+
+  useEffect(() => {
+    const handleClickOutside = (e: MouseEvent) => {
+      const target = e.target as HTMLElement
+      if (editingSessionId && !target.closest('.editing-input')) {
+        setEditingSessionId(undefined)
+      }
+      setMenuOpenSessionId(undefined)
+    }
+    document.addEventListener('click', handleClickOutside)
+    return () => {
+      document.removeEventListener('click', handleClickOutside)
+    }
+  }, [editingSessionId])
+
+  const handleSessionClick = (sessionId: string) => {
+    onSessionSelect(sessionId)
+  }
+
+  const handleDeleteSession = async (sessionId: string, e: React.MouseEvent) => {
+    e.stopPropagation()
+    window.chatHistory.deleteSession(sessionId)
+    setRecentSessions(window.chatHistory.getAllSessions())
+    setMenuOpenSessionId(undefined)
+  }
+
+  const startEditing = (session: ChatSession, e: React.MouseEvent) => {
+    e.stopPropagation()
+    setEditingSessionId(session.id)
+    setEditTitle(session.title)
+    setMenuOpenSessionId(undefined)
+  }
+
+  const saveTitle = (sessionId: string, e: React.MouseEvent | React.KeyboardEvent) => {
+    e.stopPropagation()
+    if (editTitle.trim()) {
+      window.chatHistory.updateSessionTitle(sessionId, editTitle.trim())
+      setRecentSessions(window.chatHistory.getAllSessions())
+    }
+    setEditingSessionId(undefined)
+  }
+
+  const toggleMenu = (sessionId: string, e: React.MouseEvent) => {
+    e.stopPropagation()
+    setMenuOpenSessionId(menuOpenSessionId === sessionId ? undefined : sessionId)
+  }
+
+  const handleCompositionStart = () => {
+    setIsComposing(true)
+  }
+
+  const handleCompositionEnd = () => {
+    setIsComposing(false)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent, sessionId: string) => {
+    if (isComposing) return
+
+    if (e.key === 'Enter') {
+      saveTitle(sessionId, e)
+    } else if (e.key === 'Escape') {
+      setEditingSessionId(undefined)
+    }
+  }
+
+  if (recentSessions.length === 0) {
+    return (
+      <div className="p-4 text-center text-gray-500 dark:text-gray-400">{t('No chat history')}</div>
+    )
+  }
+
+  return (
+    <div className="chat-history p-4">
+      <h2 className="text-md font-semibold mb-4 text-gray-800 dark:text-gray-200">
+        {t('Chat History')}
+      </h2>
+      <div className="session-list space-y-2">
+        {recentSessions.map((session) => (
+          <div
+            key={session.id}
+            onClick={() => handleSessionClick(session.id)}
+            className={`session-item p-3 rounded-lg cursor-pointer hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors duration-200
+              ${currentSessionId === session.id ? 'bg-gray-200 dark:bg-gray-700' : ''}`}
+          >
+            <div className="flex justify-between items-center min-h-[32px]">
+              {editingSessionId === session.id ? (
+                <div
+                  className="flex items-center w-full editing-input"
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <input
+                    type="text"
+                    value={editTitle}
+                    onChange={(e) => setEditTitle(e.target.value)}
+                    className="flex-1 px-2 py-1 text-sm border rounded dark:bg-gray-800 dark:border-gray-600 min-w-0"
+                    autoFocus
+                    onKeyDown={(e) => handleKeyDown(e, session.id)}
+                    onCompositionStart={handleCompositionStart}
+                    onCompositionEnd={handleCompositionEnd}
+                  />
+                </div>
+              ) : (
+                <div className="flex items-center justify-between w-full">
+                  <div className="relative flex-1 min-w-0 pr-2">
+                    <h3
+                      className="font-medium text-gray-800 dark:text-gray-200 text-sm truncate"
+                      title={session.title}
+                    >
+                      {session.title}
+                    </h3>
+                  </div>
+                  <div className="relative flex-shrink-0">
+                    <button
+                      onClick={(e) => toggleMenu(session.id, e)}
+                      className="text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-400 p-1 rounded-md hover:bg-gray-100 dark:hover:bg-gray-600"
+                    >
+                      <FiMoreHorizontal className="w-4 h-4" />
+                    </button>
+                    {menuOpenSessionId === session.id && (
+                      <div
+                        className="absolute right-1 mt-1 w-40 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 z-10"
+                        onClick={(e) => e.stopPropagation()}
+                      >
+                        <div className="py-1">
+                          <button
+                            onClick={(e) => startEditing(session, e)}
+                            className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2"
+                          >
+                            <FiEdit2 className="w-4 h-4" />
+                            {t('Edit title')}
+                          </button>
+                          <button
+                            onClick={(e) => handleDeleteSession(session.id, e)}
+                            className="w-full text-left px-4 py-2 text-sm text-red-600 dark:text-red-400 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2 border-t border-gray-100 dark:border-gray-700"
+                          >
+                            <FiTrash2 className="w-4 h-4" />
+                            {t('Delete')}
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/pages/ChatPage/components/ChatHistory/index.tsx
+++ b/src/renderer/src/pages/ChatPage/components/ChatHistory/index.tsx
@@ -1,8 +1,12 @@
 import React, { useEffect, useState } from 'react'
 import { ChatSession } from '@/types/chat/history'
 import { useTranslation } from 'react-i18next'
-import { FiMoreHorizontal, FiEdit2, FiTrash2 } from 'react-icons/fi'
+import { FiMoreHorizontal, FiEdit2, FiTrash2, FiZap } from 'react-icons/fi'
 import { RiArchiveStackLine } from 'react-icons/ri'
+import useSettings from '../../../../hooks/useSetting'
+import { Message } from '@aws-sdk/client-bedrock-runtime'
+import { converse } from '../../../../lib/api'
+import toast from 'react-hot-toast'
 
 interface ChatHistoryProps {
   onSessionSelect: (sessionId: string) => void
@@ -15,6 +19,8 @@ export const ChatHistory: React.FC<ChatHistoryProps> = ({ onSessionSelect, curre
   const [editTitle, setEditTitle] = useState('')
   const [menuOpenSessionId, setMenuOpenSessionId] = useState<string>()
   const [isComposing, setIsComposing] = useState(false)
+  const [isGenerating, setIsGenerating] = useState(false)
+  const { currentLLM } = useSettings()
   const { t } = useTranslation()
 
   useEffect(() => {
@@ -61,6 +67,68 @@ export const ChatHistory: React.FC<ChatHistoryProps> = ({ onSessionSelect, curre
       setRecentSessions(window.chatHistory.getAllSessions())
     }
     setEditingSessionId(undefined)
+  }
+
+  const generateAITitle = async (session: ChatSession, e: React.MouseEvent) => {
+    e.stopPropagation()
+    setIsGenerating(true)
+
+    try {
+      // チャット履歴から最新の会話内容を取得（直近5つのメッセージ）
+      const recentMessages = session.messages || []
+      const messages: Message[] = recentMessages.map((m) => ({
+        role: m.role,
+        content: m.content
+      }))
+
+      const system = [
+        {
+          text:
+            'You are an assistant who summarizes the contents of the conversation and gives it a title.' +
+            'Generate a title according to the following conditions:\n' +
+            '- Up to 15 characters long\n' +
+            '- Do not use decorative words\n' +
+            '- Express the essence of the conversation succinctly\n' +
+            '- Output the title only (no explanation required)'
+        }
+      ]
+
+      // messages の配列に含まれるテキスト要素を結合する（上限 1000 文字）
+      const joinedMsgs = messages
+        .map((m) => m.content?.map((v) => v.text).join('\n'))
+        .join('\n')
+        .slice(0, 1000)
+
+      // currentLLM を使用してタイトルを生成
+      const response = await converse({
+        modelId: currentLLM.modelId,
+        system,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                text: joinedMsgs
+              }
+            ]
+          }
+        ]
+      })
+
+      console.log({ response })
+      const newTitle = response.output.message.content[0].text
+
+      // タイトルを更新
+      window.chatHistory.updateSessionTitle(session.id, newTitle)
+      setRecentSessions(window.chatHistory.getAllSessions())
+      setMenuOpenSessionId(undefined)
+    } catch (error) {
+      console.error('Failed to generate AI title:', error)
+      // エラーメッセージを表示
+      toast.error(t('Failed to generate title'))
+    } finally {
+      setIsGenerating(false)
+    }
   }
 
   const toggleMenu = (sessionId: string, e: React.MouseEvent) => {
@@ -142,7 +210,7 @@ export const ChatHistory: React.FC<ChatHistoryProps> = ({ onSessionSelect, curre
                     </button>
                     {menuOpenSessionId === session.id && (
                       <div
-                        className="absolute right-1 mt-1 w-40 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 z-10"
+                        className="absolute right-1 mt-1 w-48 bg-white dark:bg-gray-800 rounded-md shadow-lg border border-gray-200 dark:border-gray-700 z-10"
                         onClick={(e) => e.stopPropagation()}
                       >
                         <div className="py-1">
@@ -152,6 +220,18 @@ export const ChatHistory: React.FC<ChatHistoryProps> = ({ onSessionSelect, curre
                           >
                             <FiEdit2 className="w-4 h-4" />
                             {t('Edit title')}
+                          </button>
+                          <button
+                            onClick={(e) => generateAITitle(session, e)}
+                            disabled={isGenerating}
+                            className="w-full text-left px-4 py-2 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700 flex items-center gap-2 border-t border-gray-100 dark:border-gray-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                          >
+                            {isGenerating ? (
+                              <span className="animate-spin w-4 h-4">⌛</span>
+                            ) : (
+                              <FiZap className="w-4 h-4" />
+                            )}
+                            {t('Geneate title')}
                           </button>
                           <button
                             onClick={(e) => handleDeleteSession(session.id, e)}

--- a/src/renderer/src/pages/ChatPage/components/ChatHistory/index.tsx
+++ b/src/renderer/src/pages/ChatPage/components/ChatHistory/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react'
 import { ChatSession } from '@/types/chat/history'
 import { useTranslation } from 'react-i18next'
 import { FiMoreHorizontal, FiEdit2, FiTrash2 } from 'react-icons/fi'
+import { RiArchiveStackLine } from 'react-icons/ri'
 
 interface ChatHistoryProps {
   onSessionSelect: (sessionId: string) => void
@@ -93,7 +94,8 @@ export const ChatHistory: React.FC<ChatHistoryProps> = ({ onSessionSelect, curre
 
   return (
     <div className="chat-history p-4">
-      <h2 className="text-md font-semibold mb-4 text-gray-800 dark:text-gray-200">
+      <h2 className="text-sm font-semibold mb-4 text-gray-800 dark:text-gray-200">
+        <RiArchiveStackLine className="inline-block mr-2 w-5 h-5" />
         {t('Chat History')}
       </h2>
       <div className="session-list space-y-2">

--- a/src/renderer/src/pages/ChatPage/components/InputForm/index.tsx
+++ b/src/renderer/src/pages/ChatPage/components/InputForm/index.tsx
@@ -3,6 +3,7 @@ import { AttachedImage, TextArea } from './TextArea'
 import { ToolSettings } from './ToolSettings'
 import { DirectorySelector } from './DirectorySelector'
 import { SendMsgKey } from '@/types/agent-chat'
+import { FiTrash2 } from 'react-icons/fi'
 
 type InputFormProps = {
   userInput: string
@@ -14,6 +15,8 @@ type InputFormProps = {
   onOpenToolSettings: () => void
   onSelectDirectory: () => void
   onOpenIgnoreModal: () => void
+  onClearChat: () => void
+  hasMessages: boolean
 }
 
 export const InputForm: React.FC<InputFormProps> = ({
@@ -25,7 +28,9 @@ export const InputForm: React.FC<InputFormProps> = ({
   onChange,
   onOpenToolSettings,
   onSelectDirectory,
-  onOpenIgnoreModal
+  onOpenIgnoreModal,
+  onClearChat,
+  hasMessages
 }) => {
   const [isComposing, setIsComposing] = useState(false)
 
@@ -42,6 +47,19 @@ export const InputForm: React.FC<InputFormProps> = ({
               onOpenIgnoreModal={onOpenIgnoreModal}
             />
           </div>
+
+          {/* right */}
+          {hasMessages && (
+            <div className="flex items-end mb-1">
+              <button
+                onClick={onClearChat}
+                className="p-2 text-gray-500 hover:text-gray-700 rounded-full hover:bg-gray-100 transition-colors duration-200"
+                title={'Clear chat'}
+              >
+                <FiTrash2 />
+              </button>
+            </div>
+          )}
         </div>
 
         <TextArea

--- a/src/renderer/src/pages/ChatPage/hooks/useAgentChat.ts
+++ b/src/renderer/src/pages/ChatPage/hooks/useAgentChat.ts
@@ -75,7 +75,6 @@ export const useAgentChat = (
   // メッセージの永続化を行うラッパー関数
   const persistMessage = useCallback(
     (message: Message) => {
-      console.log({ message, currentSessionId })
       if (currentSessionId && message.role && message.content) {
         const chatMessage: ChatMessage = {
           id: `msg_${Date.now()}`,

--- a/src/types/chat/history.ts
+++ b/src/types/chat/history.ts
@@ -1,0 +1,39 @@
+import { ConversationRole, ContentBlock } from '@aws-sdk/client-bedrock-runtime'
+import { ToolState } from '../agent-chat'
+
+type AttachedImage = {
+  file: File
+  preview: string
+  base64: string
+}
+
+export interface ChatMessage {
+  id: string
+  role: ConversationRole
+  content: ContentBlock[]
+  timestamp: number
+  metadata?: {
+    modelId?: string
+    tools?: ToolState[]
+    images?: AttachedImage[]
+  }
+}
+
+export interface ChatSession {
+  id: string
+  title: string
+  createdAt: number
+  updatedAt: number
+  messages: ChatMessage[]
+  agentId: string
+  systemPrompt?: string
+  modelId: string
+}
+
+export interface ChatHistoryStore {
+  sessions: {
+    [key: string]: ChatSession
+  }
+  activeSessionId?: string
+  recentSessions: string[] // 最近使用したセッションID（最大10個）
+}

--- a/src/types/preload/index.ts
+++ b/src/types/preload/index.ts
@@ -1,0 +1,21 @@
+import { ChatMessage, ChatSession } from '../chat/history'
+
+export interface ChatHistoryAPI {
+  createSession(agentId: string, modelId: string, systemPrompt?: string): string
+  addMessage(sessionId: string, message: ChatMessage): void
+  getSession(sessionId: string): ChatSession | null
+  updateSessionTitle(sessionId: string, title: string): void
+  deleteSession(sessionId: string): void
+  getRecentSessions(): ChatSession[]
+  getAllSessions(): ChatSession[]
+  setActiveSession(sessionId: string | undefined): void
+  getActiveSessionId(): string | undefined
+}
+
+// 他のAPIの型定義も同様に追加できます
+export interface PreloadAPIs {
+  chatHistory: ChatHistoryAPI
+  // store: StoreAPI
+  // file: FileAPI
+  // tools: ToolsAPI
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,6 +1,6 @@
 {
   "extends": "@electron-toolkit/tsconfig/tsconfig.node.json",
-  "include": ["electron.vite.config.*", "src/main/**/*", "src/preload/**/*", "src/types/**.d.ts", "src/test/**/*"],
+  "include": ["electron.vite.config.*", "src/main/**/*", "src/preload/**/*", "src/types/**/*", "src/test/**/*"],
   "compilerOptions": {
     "composite": true,
     "types": ["electron-vite/node"]


### PR DESCRIPTION
## 変更内容

![image](https://github.com/user-attachments/assets/87593c2b-9016-40b4-b9d3-7eb90fd4a299)
![image](https://github.com/user-attachments/assets/733b6ec5-5beb-4f87-af17-8d00bcfe5de4)


### 新機能
- チャット履歴の保存と管理機能を追加
- チャットセッションの作成、編集、削除機能を実装
- サイドパネルでチャット履歴を表示・管理できるUIを追加
- セッション間の切り替え機能を実装

### 技術的な改善
- electron-storeを使用したローカルストレージでの永続化
- チャットセッションのCRUD操作を管理するChatSessionManagerクラスを実装
- チャットメッセージのメタデータ（モデルID、ツール設定等）の保存機能を追加
- 通信の中断制御（AbortController）を実装し、セッション切り替え時の安全性を向上

### UI/UX の改善
- サイドパネルの開閉機能の実装
- チャットセッションのタイトル編集機能
- チャットクリア機能の追加
- 最近使用したセッションの優先表示

## セキュリティとパフォーマンス
- セッションデータの適切な永続化処理
- 不要なネットワークリクエストの防止
- メモリ使用量の最適化

## 影響範囲
- チャット機能全般
- UIレイアウト
- データ永続化層

## 関連Issue
Closes #24 