### PR TITLE
fix: リリースへのアーティファクト添付パスを修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,8 +129,8 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            artifacts/bedrock-engineer-mac.dmg
-            artifacts/bedrock-engineer-win-setup.exe
+            artifacts/**/*.dmg
+            artifacts/**/*.exe
           body_path: RELEASE_NOTES.md
           draft: false
           prerelease: false


### PR DESCRIPTION
## 問題\n\n現在のリリースワークフローでは、生成されたアーティファクト（Mac版とWindows版のインストーラー）がリリースに添付されていません。\n\n## 原因\n\nワークフローファイルで指定しているアーティファクトのパスが実際の生成ファイルのパスと一致していませんでした。\n\n\n\n実際の生成ファイルは以下のパスに存在しています：\n- \n- \n\n## 修正内容\n\nワイルドカードを使用して任意のサブディレクトリにある全てのdmgとexeファイルを対象とするように変更しました：\n\n\n\nこれにより、リリースに実際のインストーラーファイルが添付されるようになります。